### PR TITLE
Updated readme for using eosiojava libraries with gradle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ packagingOptions {
 }
 ```
 
+If you are using EOSIO SDK for Java, or any library that depends on it, with gradle plugin 5+ then you can't access the libraries's dependencies without declare them in your `build.gradle`
+
+Example:
+* Accessing `okhttp` classes on your code:
+```java
+
+implementation 'com.squareup.okhttp3:okhttp:version'
+
+```
+
+
 Then refresh your gradle project. Then you're all set for the [Basic Usage](#basic-usage) example!
 
 ## Helpful Utilities


### PR DESCRIPTION
Using gradle 5+ with cause some issue if developer want to access eosiojava libraries's dependencies because gradle 5 update the "implementation" to restrict access dependencies on the library declare it only. 

Developer has to declare the usage of the dependency by themself on their `build.gradle`