### PR TITLE
Feature/fix date format

### DIFF
--- a/eosiojava/build.gradle
+++ b/eosiojava/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosiojava'
-def libraryVersion = '0.1.0-feature-fix-date-format'
+def libraryVersion = '0.1.1'
 
 task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'

--- a/eosiojava/build.gradle
+++ b/eosiojava/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosiojava'
-def libraryVersion = '0.1.0'
+def libraryVersion = '0.1.0-feature-fix-date-format'
 
 task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'

--- a/eosiojava/src/main/java/one/block/eosiojava/utilities/DateFormatter.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/utilities/DateFormatter.java
@@ -14,12 +14,12 @@ public class DateFormatter {
     /**
      * Blockchain pattern for SimpleDateFormat
      */
-    public static final String BACKEND_DATE_PATTERN = "yyyy-MM-dd'T'kk:mm:ss.SSS";
+    public static final String BACKEND_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
     /**
      * Blockchain pattern for SimpleDateFormat.  It includes timezone.
      */
-    public static final String BACKEND_DATE_PATTERN_WITH_TIMEZONE = "yyyy-MM-dd'T'kk:mm:ss.SSS zzz";
+    public static final String BACKEND_DATE_PATTERN_WITH_TIMEZONE = "yyyy-MM-dd'T'HH:mm:ss.SSS zzz";
 
     /**
      * Blockchain timezone/time standard for SimpleDateFormat

--- a/eosiojava/src/test/java/one/block/eosiojava/DateFormatterTest.java
+++ b/eosiojava/src/test/java/one/block/eosiojava/DateFormatterTest.java
@@ -1,0 +1,50 @@
+package one.block.eosiojava;
+
+import java.text.ParseException;
+import one.block.eosiojava.utilities.DateFormatter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DateFormatterTest {
+
+    @Test
+    public void testConvertBackendTimeToMilli() throws ParseException {
+        this.convertStrDateToMilliAndVerify("2019-09-11T19:38:05.000");
+        this.convertStrDateToMilliAndVerify("2019-01-01T19:38:05.000");
+        this.convertStrDateToMilliAndVerify("2019-09-11T00:38:05.000");
+        this.convertStrDateToMilliAndVerify("2019-09-11T00:00:00.000");
+        this.convertStrDateToMilliAndVerify("2019-01-01T00:00:00.000");
+        this.convertStrDateToMilliAndVerify("1900-01-01T00:00:00.000");
+    }
+
+    @Test
+    public void testIncreaseTime() throws ParseException {
+        this.increaseTimeByMilliSecondToStrDateAndVerify("2019-09-11T19:38:05.000", 300 * 1000,
+                "2019-09-11T19:43:05.000");
+        this.increaseTimeByMilliSecondToStrDateAndVerify("2019-01-01T19:38:05.000", 180 * 1000,
+                "2019-01-01T19:41:05.000");
+        this.increaseTimeByMilliSecondToStrDateAndVerify("2019-09-11T00:38:05.000", 600 * 1000,
+                "2019-09-11T00:48:05.000");
+        this.increaseTimeByMilliSecondToStrDateAndVerify("2019-09-11T00:00:00.000", 300 * 1000,
+                "2019-09-11T00:05:00.000");
+        this.increaseTimeByMilliSecondToStrDateAndVerify("2019-01-01T00:00:00.000", 300 * 1000,
+                "2019-01-01T00:05:00.000");
+        this.increaseTimeByMilliSecondToStrDateAndVerify("1900-01-01T00:00:00.000", 300 * 1000,
+                "1900-01-01T00:05:00.000");
+    }
+
+    private void convertStrDateToMilliAndVerify(String strDate) throws ParseException {
+        long milliSeconds = DateFormatter.convertBackendTimeToMilli(strDate);
+        String convertedStrDate = DateFormatter.convertMilliSecondToBackendTimeString(milliSeconds);
+        Assert.assertEquals(strDate, convertedStrDate);
+    }
+
+    private void increaseTimeByMilliSecondToStrDateAndVerify(String strDate,
+            long appendMilliSeconds, String strDateAfterAppended)
+            throws ParseException {
+        long milliSeconds = DateFormatter.convertBackendTimeToMilli(strDate);
+        milliSeconds += appendMilliSeconds;
+        String convertedStrDate = DateFormatter.convertMilliSecondToBackendTimeString(milliSeconds);
+        Assert.assertEquals(strDateAfterAppended, convertedStrDate);
+    }
+}


### PR DESCRIPTION
Issue: When a transaction gets prepared, an expiration date will be calculated by this formula: 
expiration time = head block time + default expiration period.

The head block time get converted to milliseconds to run the above formula and the conversion has a bug which will happen when head block time is from "month-day-yearT00:00:00" to "month-day-yearT59:59:00". 

The wrong pattern to convert the date time is "yyyy-MM-dd'T'kk:mm:ss.SSS" which has kk (1-24) for the hour of the date. After the head block time get appended, it get converted back to string but now the converter confuse about "00" and "24" for the hour part. Then it convert the head block time to the next day. 

Example: "01-01-2019T00:01:01" will be converted to "01-02-2019T00:06:01"

The chain will reject the invalid transaction because its expiration period is too long (1 day + default expiration period). The error you should get back is similar to "Transaction expiration is too far in the future relative to the reference time of 01-01-2019T00:04:01, expiration is 01-02-2019T00:06:01 and the maximum transaction lifetime is 3600 seconds"

By replacing "yyyy-MM-dd'T'kk:mm:ss.SSS" with "yyyy-MM-dd'T'HH:mm:ss.SSS". It fix the bug. 