### PR TITLE
Add support for action return values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ actions.add(new Action("eosio.token", "transfer", authorizations, jsonData));
 processor.prepare(actions);
 
 SendTransactionResponse sendTransactionResponse = processor.signAndBroadcast();
+
+// Starting with EOSIO 2.1 actions can have return values associated with them.
+// If the actions have return values they can be accessed from the response.
+ArrayList<Object> actionReturnValues = sendTransactionResponse.getActionValues();
+
+// Or
+try {
+    Double actionReturnValue = response.getActionValueAtIndex(index, Double.class);
+} catch (IndexOutOfBoundsException outOfBoundsError) {
+    // Handle out of bounds error
+} catch (ClassCastException castError) {
+    // Handle class casting error
+}
 ```
 
 ## Android Example App

--- a/eosiojava/build.gradle
+++ b/eosiojava/build.gradle
@@ -47,7 +47,7 @@ test {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosiojava'
-def libraryVersion = '0.1.3-eosio2.1'
+def libraryVersion = '0.1.4-eosio2.1'
 
 task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/Action.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/Action.java
@@ -50,6 +50,11 @@ public class Action implements Serializable {
     private boolean isContextFree;
 
     /**
+     * Action return value after transaction processing.
+     */
+    private transient Object returnValue;
+
+    /**
      * Instantiates a new action.
      *
      * @param account the Contract account name.
@@ -171,4 +176,22 @@ public class Action implements Serializable {
      * @param isContextFree whether or not this action is context free.
      */
     public void setIsContextFree(@NotNull boolean isContextFree) { this.isContextFree = isContextFree; }
+
+    /**
+     * Gets the action's return value after transaction processing.
+     * @return returnValue action return value after transaction processing.  If there wasn't one, returns null.
+     */
+    public Object getReturnValue() {
+        return returnValue;
+    }
+
+    /**
+     * Sets the action return value.
+     * @param returnValue return value of the action after transaction processing, if there is one.  If there is not,
+     *                    the value should be null.
+     */
+    public void setReturnValue(Object returnValue) {
+        this.returnValue = returnValue;
+    }
+
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/SendTransactionRequest.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/SendTransactionRequest.java
@@ -7,34 +7,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * The request of SendTransactionRequest RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#sendTransaction(SendTransactionRequest)}
  */
-public class SendTransactionRequest {
-
-    /**
-     * List of signatures required to authorize transaction
-     */
-    @SerializedName("signatures")
-    @NotNull
-    private List<String> signatures;
-
-    /**
-     * The compression used, usually 0.
-     */
-    @SerializedName("compression")
-    private int compression;
-
-    /**
-     * Context free data in hex
-     */
-    @SerializedName("packed_context_free_data")
-    private String packagedContextFreeData;
-
-    /**
-     * The Pack Transaction (Serialized Transaction).
-     * <br> It is serialized version of {@link one.block.eosiojava.models.rpcProvider.Transaction}.
-     */
-    @SerializedName("packed_trx")
-    @NotNull
-    private String packTrx;
+public class SendTransactionRequest extends PushTransactionRequest {
 
     /**
      * Instantiates a new SendTransactionRequest.
@@ -47,10 +20,7 @@ public class SendTransactionRequest {
      */
     public SendTransactionRequest(@NotNull List<String> signatures, int compression,
             String packagedContextFreeData, @NotNull String packTrx) {
-        this.signatures = signatures;
-        this.compression = compression;
-        this.packagedContextFreeData = packagedContextFreeData;
-        this.packTrx = packTrx;
+        super(signatures, compression, packagedContextFreeData, packTrx);
     }
 
     /**
@@ -60,7 +30,7 @@ public class SendTransactionRequest {
      */
     @NotNull
     public List<String> getSignatures() {
-        return signatures;
+        return super.getSignatures();
     }
 
     /**
@@ -69,7 +39,7 @@ public class SendTransactionRequest {
      * @param signatures the list of signatures.
      */
     public void setSignatures(@NotNull List<String> signatures) {
-        this.signatures = signatures;
+        super.setSignatures(signatures);
     }
 
     /**
@@ -78,7 +48,7 @@ public class SendTransactionRequest {
      * @return the compression.
      */
     public int getCompression() {
-        return compression;
+        return super.getCompression();
     }
 
     /**
@@ -87,7 +57,7 @@ public class SendTransactionRequest {
      * @param compression the compression.
      */
     public void setCompression(int compression) {
-        this.compression = compression;
+        super.setCompression(compression);
     }
 
     /**
@@ -96,7 +66,7 @@ public class SendTransactionRequest {
      * @return the packaged context free data in hex.
      */
     public String getPackagedContextFreeData() {
-        return packagedContextFreeData;
+        return super.getPackagedContextFreeData();
     }
 
     /**
@@ -105,7 +75,7 @@ public class SendTransactionRequest {
      * @param packagedContextFreeData the packaged context free data in hex.
      */
     public void setPackagedContextFreeData(String packagedContextFreeData) {
-        this.packagedContextFreeData = packagedContextFreeData;
+        super.setPackagedContextFreeData(packagedContextFreeData);
     }
 
     /**
@@ -116,7 +86,7 @@ public class SendTransactionRequest {
      */
     @NotNull
     public String getPackTrx() {
-        return packTrx;
+        return super.getPackTrx();
     }
 
     /**
@@ -126,6 +96,6 @@ public class SendTransactionRequest {
      * @param packTrx the packed transaction (serialized transaction).
      */
     public void setPackTrx(@NotNull String packTrx) {
-        this.packTrx = packTrx;
+        super.setPackTrx(packTrx);
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/PushTransactionResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/PushTransactionResponse.java
@@ -1,6 +1,10 @@
 package one.block.eosiojava.models.rpcProvider.response;
 
 import com.google.gson.annotations.SerializedName;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import one.block.eosiojava.models.rpcProvider.request.PushTransactionRequest;
 
@@ -28,7 +32,46 @@ public class PushTransactionResponse {
         return transactionId;
     }
 
+    /**
+     * Gets the processed detail information of the successful transaction.
+     *
+     * @return The successful processed details of the transaction.
+     */
     public Map getProcessed() {
         return processed;
+    }
+
+    /**
+     * Return action values, if any.  The returned values are placed in their respective actions.
+     * The array must contain null for the actions that do not return action values.
+     * There may be more action values than input actions due to inline actions or notifications
+     * but input (request) actions are always returned first and in the same order as they were
+     * submitted.
+     *
+     * @return ArrayList of Objects containing the return values from the response.
+     */
+    public ArrayList<Object> getActionValues() {
+        ArrayList<Object> returnValues = new ArrayList<Object>();
+        if (processed == null) { return returnValues; }
+        if (!processed.containsKey("action_traces")) { return returnValues; }
+        for (Map trace : (List<Map>) processed.get("action_traces")) {
+            returnValues.add(trace.getOrDefault("return_value_data", null));
+        }
+        return returnValues;
+    }
+
+    /**
+     * Get the action value at the specified index, if it exists and return it as the passed in type.
+     * @param index The index of the action value returns to retrieve.
+     * @param clazz The class type to cast the action value to, if found.
+     * @return The action value as the desired type or null if not found or is the wrong type.
+     * @throws ClassCastException if the value cannot be cast to the requested type.
+     * @throws IndexOutOfBoundsException if an incorrect index is requested.
+     */
+    public <T> T getActionValueAtIndex(int index, Class<T> clazz) throws IndexOutOfBoundsException, ClassCastException {
+        ArrayList<Object> actionValues = getActionValues();
+        if (actionValues == null) { return null; }
+        Object actionValuesObj = actionValues.get(index);
+        return clazz.cast(actionValuesObj);
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/SendTransactionResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/SendTransactionResponse.java
@@ -1,6 +1,8 @@
 package one.block.eosiojava.models.rpcProvider.response;
 
 import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
 import java.util.Map;
 import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
 
@@ -8,16 +10,7 @@ import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
  * The response of the sendTransaction() RPC call
  * {@link one.block.eosiojava.interfaces.IRPCProvider#sendTransaction(SendTransactionRequest)}
  */
-public class SendTransactionResponse {
-
-    /**
-     * The transaction id of the successful transaction.
-     */
-    @SerializedName("transaction_id")
-    private String transactionId;
-
-    @SerializedName("processed")
-    private Map processed;
+public class SendTransactionResponse extends PushTransactionResponse {
 
     /**
      * Gets the transaction id of the successful transaction.
@@ -25,10 +18,40 @@ public class SendTransactionResponse {
      * @return The successful transaction id.
      */
     public String getTransactionId() {
-        return transactionId;
+        return super.getTransactionId();
     }
 
+    /**
+     * Gets the processed detail information of the successful transaction.
+     *
+     * @return The successful processed details of the transaction.
+     */
     public Map getProcessed() {
-        return processed;
+        return super.getProcessed();
+    }
+
+    /**
+     * Return action values, if any.  The returned values are placed in their respective actions.
+     * The array must contain null for the actions that do not return action values.
+     * There may be more action values than input actions due to inline actions or notifications
+     * but input (request) actions are always returned first and in the same order as they were
+     * submitted.
+     *
+     * @return ArrayList of Objects containing the return values from the response.
+     */
+    public ArrayList<Object> getActionValues() {
+        return super.getActionValues();
+    }
+
+    /**
+     * Get the action value at the specified index, if it exists and return it as the passed in type.
+     * @param index The index of the action value returns to retrieve.
+     * @param clazz The class type to cast the action value to, if found.
+     * @return The action value as the desired type or null if not found or is the wrong type.
+     * @throws ClassCastException if the value cannot be cast to the requested type.
+     * @throws IndexOutOfBoundsException if an incorrect index is requested.
+     */
+    public <T> T getActionValueAtIndex(int index, Class<T> clazz) throws IndexOutOfBoundsException, ClassCastException {
+        return super.getActionValueAtIndex(index, clazz);
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/session/TransactionProcessor.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/session/TransactionProcessor.java
@@ -903,11 +903,7 @@ public class TransactionProcessor {
 
         try {
             this.serializationProvider.serialize(actionAbiEosSerializationObject);
-            if (actionAbiEosSerializationObject.getHex().isEmpty()) {
-                throw new TransactionCreateSignatureRequestSerializationError(
-                        ErrorConstants.TRANSACTION_PROCESSOR_SERIALIZE_ACTION_WORKED_BUT_EMPTY_RESULT);
-            }
-        } catch (SerializeError | TransactionCreateSignatureRequestSerializationError serializeError) {
+        } catch (SerializeError serializeError) {
             throw new TransactionCreateSignatureRequestSerializationError(
                     String.format(ErrorConstants.TRANSACTION_PROCESSOR_SERIALIZE_ACTION_ERROR,
                             action.getAccount()), serializeError);


### PR DESCRIPTION
Add two new methods to PushTransactionResponse and SendTransactionResponse.

`public ArrayList<Object> getActionValues()` - gets the action values for all actions in the response.  There can be more response actions than input actions due to inline actions or notifications but input actions are returned first and in the same order as sent in the request.  For this reason the ArrayList will contain null for any actions that do not have return values in order to maintain an 1-1 index.

`public <T> T getActionValueAtIndex(int index, Class<T> clazz) throws IndexOutOfBoundsException, ClassCastException` - convenience function to return the action value at the specified index, casting it to the anticipated class type.  Exceptions are thrown for out of index or casting errors since null is a valid return if the action index requested did not have a return value.