### PR TITLE
Add support for get_block_info and get_kv_table_rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,22 @@ To date, EOSIO SDK for Java has only been tested on Android. The goal, however, 
 
 ## Updates
 
-10/9/2020
+10/22/20
+Version 0.1.5 
+Adds support for GetBlockInfo which replaces GetBlock in IRPCProvider as the preferred way to calculate TAPOS for transactions.  GetBlock is still available.
+Removes PushTransaction from IRPCProvider in favor of SendTransaction.  PushTransaction is still available.
 
-Version 0.1.3 Adds support for send_transaction endpoint, return values and kv tables.
+10/9/2020
+Version 0.1.3 
+Adds support for send_transaction endpoint, return values and kv tables.
 
 2/25/20
-
-Version 0.1.2 Uses JDK11 to build and targets 1.8 for source and target compatibility.
+Version 0.1.2
+Uses JDK11 to build and targets 1.8 for source and target compatibility.
 
 2/21/20
-
-Version 0.1.1 Fixes a transaction expiration error.
+Version 0.1.1
+Fixes a transaction expiration error.
 
 ## Installation
 
@@ -53,10 +58,10 @@ Since EOSIO SDK for Java is not an Android specific project, we recommend using 
 To use EOSIO SDK for Java in your app, add the following modules to your build.gradle:
 
 ```groovy
-implementation 'one.block:eosiojava:0.1.3'
+implementation 'one.block:eosiojava:0.1.5'
 implementation 'one.block:eosiojavasoftkeysignatureprovider:0.1.3'
 implementation 'one.block:eosiojavaandroidabieosserializationprovider:0.1.3'
-implementation 'one.block:eosio-java-rpc-provider:0.1.3'
+implementation 'one.block:eosio-java-rpc-provider:0.1.4'
 ```
 
 If you are using EOSIO SDK for Java, or any library that depends on it, in an Android application, you must also add the following to your application's `build.gradle` file in the `android` section:
@@ -158,7 +163,7 @@ The RPC Provider is responsible for all [RPC calls to nodeos](https://developers
 EOSIO SDK for Java _does not include_ an RPC provider implementation; one must be installed separately.
 
 * [IRPCProvider](eosiojava/src/main/java/one/block/eosiojava/interfaces/IRPCProvider.java)
-* [Default RPC Provder](https://github.com/EOSIO/eosio-java-android-rpc-provider) - Currently supports Android 6 (Marshmallow)+
+* [Default RPC Provder](https://github.com/EOSIO/eosio-java-android-rpc-provider) - Currently supports Android 6 (Marshmallow)+ as well as non-Android Java platforms
 * [Nodeos RPC Reference Documentation](https://developers.eos.io/eosio-nodeos/reference)
 
 *_Alternate RPC providers can be used assuming they conform to the minimal [RPC Provider Interface](eosiojava/src/main/java/one/block/eosiojava/interfaces/IRPCProvider.java). The core EOSIO SDK for Java library depends only on the five RPC endpoints set forth in that Interface. Other endpoints, however, are planned to be exposed in the [default RPC provider](https://github.com/EOSIO/eosio-java-android-rpc-provider)._

--- a/eosiojava/build.gradle
+++ b/eosiojava/build.gradle
@@ -47,7 +47,7 @@ test {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosiojava'
-def libraryVersion = '0.1.4-eosio2.1'
+def libraryVersion = '0.1.5-eosio2.1'
 
 task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'

--- a/eosiojava/src/main/java/one/block/eosiojava/error/ErrorConstants.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/error/ErrorConstants.java
@@ -162,9 +162,9 @@ public class ErrorConstants {
     public static final String TRANSACTION_PROCESSOR_RPC_GET_INFO = "Error happened on calling GetInfo RPC.";
 
     /**
-     * Error message get thrown if {@link IRPCProvider#getBlock(GetBlockRequest)} thrown exception during process of {@link TransactionProcessor#prepare(List)}
+     * Error message get thrown if {@link IRPCProvider#getBlockInfo(GetBlockInfoRequest)} thrown exception during process of {@link TransactionProcessor#prepare(List)}
      */
-    public static final String TRANSACTION_PROCESSOR_PREPARE_RPC_GET_BLOCK = "Error happened on calling GetBlock RPC.";
+    public static final String TRANSACTION_PROCESSOR_PREPARE_RPC_GET_BLOCK_INFO = "Error happened on calling GetBlockInfo RPC.";
 
     /**
      * Error message get thrown if chain id from {@link GetInfoResponse#getChainId()} does not match with the input chain id

--- a/eosiojava/src/main/java/one/block/eosiojava/error/rpcProvider/GetBlockInfoRpcError.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/error/rpcProvider/GetBlockInfoRpcError.java
@@ -1,0 +1,25 @@
+package one.block.eosiojava.error.rpcProvider;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Error class is used when there is an exception while attempting to use the RPC call, getBlockInfo().
+ */
+public class GetBlockInfoRpcError extends RpcProviderError{
+
+    public GetBlockInfoRpcError() {
+    }
+
+    public GetBlockInfoRpcError(@NotNull String message) {
+        super(message);
+    }
+
+    public GetBlockInfoRpcError(@NotNull String message,
+                            @NotNull Exception exception) {
+        super(message, exception);
+    }
+
+    public GetBlockInfoRpcError(@NotNull Exception exception) {
+        super(exception);
+    }
+}

--- a/eosiojava/src/main/java/one/block/eosiojava/interfaces/IRPCProvider.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/interfaces/IRPCProvider.java
@@ -56,17 +56,6 @@ public interface IRPCProvider {
     /**
      * This method expects a transaction in JSON format and will attempt to apply it to the blockchain.
      *
-     * @param pushTransactionRequest the transaction to push with signatures.
-     * @return the push transaction response
-     * @throws PushTransactionRpcError thrown if there are any exceptions/backend error during the
-     * pushTransaction() process.
-     */
-    @NotNull
-    PushTransactionResponse pushTransaction(PushTransactionRequest pushTransactionRequest) throws PushTransactionRpcError;
-
-    /**
-     * This method expects a transaction in JSON format and will attempt to apply it to the blockchain.
-     *
      * @param sendTransactionRequest the transaction to push with signatures.
      * @return the send transaction response
      * @throws SendTransactionRpcError thrown if there are any exceptions/backend error during the

--- a/eosiojava/src/main/java/one/block/eosiojava/interfaces/IRPCProvider.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/interfaces/IRPCProvider.java
@@ -1,22 +1,8 @@
 package one.block.eosiojava.interfaces;
 
-import one.block.eosiojava.error.rpcProvider.GetBlockRpcError;
-import one.block.eosiojava.error.rpcProvider.GetInfoRpcError;
-import one.block.eosiojava.error.rpcProvider.GetRawAbiRpcError;
-import one.block.eosiojava.error.rpcProvider.GetRequiredKeysRpcError;
-import one.block.eosiojava.error.rpcProvider.PushTransactionRpcError;
-import one.block.eosiojava.error.rpcProvider.SendTransactionRpcError;
-import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
-import one.block.eosiojava.models.rpcProvider.request.GetRawAbiRequest;
-import one.block.eosiojava.models.rpcProvider.request.GetRequiredKeysRequest;
-import one.block.eosiojava.models.rpcProvider.request.PushTransactionRequest;
-import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
-import one.block.eosiojava.models.rpcProvider.response.GetBlockResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetInfoResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetRawAbiResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetRequiredKeysResponse;
-import one.block.eosiojava.models.rpcProvider.response.PushTransactionResponse;
-import one.block.eosiojava.models.rpcProvider.response.SendTransactionResponse;
+import one.block.eosiojava.error.rpcProvider.*;
+import one.block.eosiojava.models.rpcProvider.request.*;
+import one.block.eosiojava.models.rpcProvider.response.*;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -37,13 +23,13 @@ public interface IRPCProvider {
     /**
      * Returns an object containing various details about a specific block on the blockchain.
      *
-     * @param getBlockRequest Info of a specific block.
+     * @param getBlockInfoRequest Info of a specific block.
      * @return the info/status of a specific block in the request
-     * @throws GetBlockRpcError thrown if there are any exceptions/backend error during the
-     * getBlock() process.
+     * @throws GetBlockInfoRpcError thrown if there are any exceptions/backend error during the
+     * getBlockInfo() process.
      */
     @NotNull
-    GetBlockResponse getBlock(GetBlockRequest getBlockRequest) throws GetBlockRpcError;
+    GetBlockInfoResponse getBlockInfo(GetBlockInfoRequest getBlockInfoRequest) throws GetBlockInfoRpcError;
 
     /**
      * Gets raw abi for a given contract.

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/GetBlockInfoRequest.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/GetBlockInfoRequest.java
@@ -1,0 +1,47 @@
+package one.block.eosiojava.models.rpcProvider.request;
+
+import com.google.gson.annotations.SerializedName;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigInteger;
+
+/**
+ * The request class for getBlockInfo() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockInfoRequest)}
+ */
+public class GetBlockInfoRequest {
+
+    /**
+     * Instantiates a new GetBlockInfoRequest.
+     *
+     * @param blockNum the block number
+     */
+    public GetBlockInfoRequest(@NotNull BigInteger blockNum) {
+        this.blockNum = blockNum;
+    }
+
+    /**
+     * Provide a block number
+     */
+    @SerializedName("block_num")
+    @NotNull
+    private BigInteger blockNum;
+
+    /**
+     * Gets block number.
+     *
+     * @return the block number
+     */
+    @NotNull
+    public BigInteger getBlockNum() {
+        return blockNum;
+    }
+
+    /**
+     * Sets block number.
+     *
+     * @param blockNum the block number
+     */
+    public void setBlockNum(@NotNull BigInteger blockNum) {
+        this.blockNum = blockNum;
+    }
+}

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/PushTransactionRequest.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/PushTransactionRequest.java
@@ -5,36 +5,9 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The request of PushTransactionRequest RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#pushTransaction(PushTransactionRequest)}
+ * The request of PushTransactionRequest RPC call.
  */
-public class PushTransactionRequest {
-
-    /**
-     * List of signatures required to authorize transaction
-     */
-    @SerializedName("signatures")
-    @NotNull
-    private List<String> signatures;
-
-    /**
-     * The compression used, usually 0.
-     */
-    @SerializedName("compression")
-    private int compression;
-
-    /**
-     * Context free data in hex
-     */
-    @SerializedName("packed_context_free_data")
-    private String packagedContextFreeData;
-
-    /**
-     * The Pack Transaction (Serialized Transaction).
-     * <br> It is serialized version of {@link one.block.eosiojava.models.rpcProvider.Transaction}.
-     */
-    @SerializedName("packed_trx")
-    @NotNull
-    private String packTrx;
+public class PushTransactionRequest extends SendTransactionRequest {
 
     /**
      * Instantiates a new PushTransactionRequest.
@@ -47,10 +20,7 @@ public class PushTransactionRequest {
      */
     public PushTransactionRequest(@NotNull List<String> signatures, int compression,
             String packagedContextFreeData, @NotNull String packTrx) {
-        this.signatures = signatures;
-        this.compression = compression;
-        this.packagedContextFreeData = packagedContextFreeData;
-        this.packTrx = packTrx;
+        super(signatures, compression, packagedContextFreeData, packTrx);
     }
 
     /**
@@ -60,7 +30,7 @@ public class PushTransactionRequest {
      */
     @NotNull
     public List<String> getSignatures() {
-        return signatures;
+        return super.getSignatures();
     }
 
     /**
@@ -69,7 +39,7 @@ public class PushTransactionRequest {
      * @param signatures the list of signatures.
      */
     public void setSignatures(@NotNull List<String> signatures) {
-        this.signatures = signatures;
+        super.setSignatures(signatures);
     }
 
     /**
@@ -78,7 +48,7 @@ public class PushTransactionRequest {
      * @return the compression.
      */
     public int getCompression() {
-        return compression;
+        return super.getCompression();
     }
 
     /**
@@ -87,7 +57,7 @@ public class PushTransactionRequest {
      * @param compression the compression.
      */
     public void setCompression(int compression) {
-        this.compression = compression;
+        super.setCompression(compression);
     }
 
     /**
@@ -96,7 +66,7 @@ public class PushTransactionRequest {
      * @return the packaged context free data in hex.
      */
     public String getPackagedContextFreeData() {
-        return packagedContextFreeData;
+        return super.getPackagedContextFreeData();
     }
 
     /**
@@ -105,7 +75,7 @@ public class PushTransactionRequest {
      * @param packagedContextFreeData the packaged context free data in hex.
      */
     public void setPackagedContextFreeData(String packagedContextFreeData) {
-        this.packagedContextFreeData = packagedContextFreeData;
+        super.setPackagedContextFreeData(packagedContextFreeData);
     }
 
     /**
@@ -116,7 +86,7 @@ public class PushTransactionRequest {
      */
     @NotNull
     public String getPackTrx() {
-        return packTrx;
+        return super.getPackTrx();
     }
 
     /**
@@ -126,6 +96,6 @@ public class PushTransactionRequest {
      * @param packTrx the packed transaction (serialized transaction).
      */
     public void setPackTrx(@NotNull String packTrx) {
-        this.packTrx = packTrx;
+        super.setPackTrx(packTrx);
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/SendTransactionRequest.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/SendTransactionRequest.java
@@ -7,7 +7,34 @@ import org.jetbrains.annotations.NotNull;
 /**
  * The request of SendTransactionRequest RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#sendTransaction(SendTransactionRequest)}
  */
-public class SendTransactionRequest extends PushTransactionRequest {
+public class SendTransactionRequest {
+
+    /**
+     * List of signatures required to authorize transaction
+     */
+    @SerializedName("signatures")
+    @NotNull
+    private List<String> signatures;
+
+    /**
+     * The compression used, usually 0.
+     */
+    @SerializedName("compression")
+    private int compression;
+
+    /**
+     * Context free data in hex
+     */
+    @SerializedName("packed_context_free_data")
+    private String packagedContextFreeData;
+
+    /**
+     * The Pack Transaction (Serialized Transaction).
+     * <br> It is serialized version of {@link one.block.eosiojava.models.rpcProvider.Transaction}.
+     */
+    @SerializedName("packed_trx")
+    @NotNull
+    private String packTrx;
 
     /**
      * Instantiates a new SendTransactionRequest.
@@ -19,8 +46,11 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * of {@link one.block.eosiojava.models.rpcProvider.Transaction}.
      */
     public SendTransactionRequest(@NotNull List<String> signatures, int compression,
-            String packagedContextFreeData, @NotNull String packTrx) {
-        super(signatures, compression, packagedContextFreeData, packTrx);
+                                  String packagedContextFreeData, @NotNull String packTrx) {
+        this.signatures = signatures;
+        this.compression = compression;
+        this.packagedContextFreeData = packagedContextFreeData;
+        this.packTrx = packTrx;
     }
 
     /**
@@ -30,7 +60,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      */
     @NotNull
     public List<String> getSignatures() {
-        return super.getSignatures();
+        return signatures;
     }
 
     /**
@@ -39,7 +69,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * @param signatures the list of signatures.
      */
     public void setSignatures(@NotNull List<String> signatures) {
-        super.setSignatures(signatures);
+        this.signatures = signatures;
     }
 
     /**
@@ -48,7 +78,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * @return the compression.
      */
     public int getCompression() {
-        return super.getCompression();
+        return compression;
     }
 
     /**
@@ -57,7 +87,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * @param compression the compression.
      */
     public void setCompression(int compression) {
-        super.setCompression(compression);
+        this.compression = compression;
     }
 
     /**
@@ -66,7 +96,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * @return the packaged context free data in hex.
      */
     public String getPackagedContextFreeData() {
-        return super.getPackagedContextFreeData();
+        return packagedContextFreeData;
     }
 
     /**
@@ -75,7 +105,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * @param packagedContextFreeData the packaged context free data in hex.
      */
     public void setPackagedContextFreeData(String packagedContextFreeData) {
-        super.setPackagedContextFreeData(packagedContextFreeData);
+        this.packagedContextFreeData = packagedContextFreeData;
     }
 
     /**
@@ -86,7 +116,7 @@ public class SendTransactionRequest extends PushTransactionRequest {
      */
     @NotNull
     public String getPackTrx() {
-        return super.getPackTrx();
+        return packTrx;
     }
 
     /**
@@ -96,6 +126,6 @@ public class SendTransactionRequest extends PushTransactionRequest {
      * @param packTrx the packed transaction (serialized transaction).
      */
     public void setPackTrx(@NotNull String packTrx) {
-        super.setPackTrx(packTrx);
+        this.packTrx = packTrx;
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/GetBlockInfoResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/GetBlockInfoResponse.java
@@ -1,0 +1,139 @@
+package one.block.eosiojava.models.rpcProvider.response;
+
+import com.google.gson.annotations.SerializedName;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
+
+/**
+ * The response of getBlockInfo() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
+ */
+public class GetBlockInfoResponse {
+
+    /**
+     * The timestamp for the block from blockchain.
+     * <br>
+     *     Format: Date/time string in the format YYYY-MM-DDTHH:MM:SS.sss
+     */
+    @SerializedName("timestamp")
+    private String timestamp;
+
+    /**
+     * The block producer name.
+     */
+    @SerializedName("producer")
+    private String producer;
+
+    @SerializedName("confirmed")
+    private BigInteger confirmed;
+
+    @SerializedName("previous")
+    private String previous;
+
+    @SerializedName("transaction_mroot")
+    private String transactionMroot;
+
+    @SerializedName("action_mroot")
+    private String actionMroot;
+
+    @SerializedName("schedule_version")
+    private BigInteger  scheduleVersion;
+
+    @SerializedName("producer_signature")
+    private String producerSignature;
+
+    /**
+     * The block id
+     */
+    @SerializedName("id")
+    private String id;
+
+    /**
+     * The block number. This is used to construct the refBlockNum of
+     * {@link one.block.eosiojava.models.rpcProvider.Transaction}.
+     */
+    @SerializedName("block_num")
+    private BigInteger  blockNum;
+
+    /**
+     * The reference block prefix. This is used to construct refBlockPrefix of
+     * {@link one.block.eosiojava.models.rpcProvider.Transaction}.
+     */
+    @SerializedName("ref_block_prefix")
+    private BigInteger  refBlockPrefix;
+
+    /**
+     * Gets the timestamp for the block from the blockchain.
+     * <br>
+     *      Format: Date/time string in the format YYYY-MM-DDTHH:MM:SS.sss.
+     *
+     * @return the timestamp
+     */
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Gets the block producer name.
+     *
+     * @return block producer name
+     */
+    public String getProducer() {
+        return producer;
+    }
+
+    public BigInteger getConfirmed() {
+        return confirmed;
+    }
+
+    public String getPrevious() {
+        return previous;
+    }
+
+    public String getTransactionMroot() {
+        return transactionMroot;
+    }
+
+    public String getActionMroot() {
+        return actionMroot;
+    }
+
+    public BigInteger  getScheduleVersion() {
+        return scheduleVersion;
+    }
+
+    public String getProducerSignature() {
+        return producerSignature;
+    }
+
+    /**
+     * Gets the block id.
+     *
+     * @return the block id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the block number. Which is used to construct refBlockNum field of
+     * {@link one.block.eosiojava.models.rpcProvider.Transaction}
+     *
+     * @return the block number.
+     */
+    public BigInteger  getBlockNum() {
+        return blockNum;
+    }
+
+    /**
+     * Gets reference block prefix. This is used for refBlockPrefix field of
+     * {@link one.block.eosiojava.models.rpcProvider.Transaction}.
+     *
+     * @return the ref block prefix
+     */
+    public BigInteger  getRefBlockPrefix() {
+        return refBlockPrefix;
+    }
+}
+

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/PushTransactionResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/PushTransactionResponse.java
@@ -12,16 +12,7 @@ import one.block.eosiojava.models.rpcProvider.request.PushTransactionRequest;
  * The response of the pushTransaction() RPC call
  * {@link one.block.eosiojava.interfaces.IRPCProvider#pushTransaction(PushTransactionRequest)}
  */
-public class PushTransactionResponse {
-
-    /**
-     * The transaction id of the successful transaction.
-     */
-    @SerializedName("transaction_id")
-    private String transactionId;
-
-    @SerializedName("processed")
-    private Map processed;
+public class PushTransactionResponse extends SendTransactionResponse {
 
     /**
      * Gets the transaction id of the successful transaction.
@@ -29,7 +20,7 @@ public class PushTransactionResponse {
      * @return The successful transaction id.
      */
     public String getTransactionId() {
-        return transactionId;
+        return super.getTransactionId();
     }
 
     /**
@@ -38,7 +29,7 @@ public class PushTransactionResponse {
      * @return The successful processed details of the transaction.
      */
     public Map getProcessed() {
-        return processed;
+        return super.getProcessed();
     }
 
     /**
@@ -51,13 +42,7 @@ public class PushTransactionResponse {
      * @return ArrayList of Objects containing the return values from the response.
      */
     public ArrayList<Object> getActionValues() {
-        ArrayList<Object> returnValues = new ArrayList<Object>();
-        if (processed == null) { return returnValues; }
-        if (!processed.containsKey("action_traces")) { return returnValues; }
-        for (Map trace : (List<Map>) processed.get("action_traces")) {
-            returnValues.add(trace.getOrDefault("return_value_data", null));
-        }
-        return returnValues;
+        return super.getActionValues();
     }
 
     /**
@@ -69,9 +54,6 @@ public class PushTransactionResponse {
      * @throws IndexOutOfBoundsException if an incorrect index is requested.
      */
     public <T> T getActionValueAtIndex(int index, Class<T> clazz) throws IndexOutOfBoundsException, ClassCastException {
-        ArrayList<Object> actionValues = getActionValues();
-        if (actionValues == null) { return null; }
-        Object actionValuesObj = actionValues.get(index);
-        return clazz.cast(actionValuesObj);
+        return super.getActionValueAtIndex(index, clazz);
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/SendTransactionResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/SendTransactionResponse.java
@@ -2,7 +2,9 @@ package one.block.eosiojava.models.rpcProvider.response;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
 
@@ -10,7 +12,16 @@ import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
  * The response of the sendTransaction() RPC call
  * {@link one.block.eosiojava.interfaces.IRPCProvider#sendTransaction(SendTransactionRequest)}
  */
-public class SendTransactionResponse extends PushTransactionResponse {
+public class SendTransactionResponse {
+
+    /**
+     * The transaction id of the successful transaction.
+     */
+    @SerializedName("transaction_id")
+    private String transactionId;
+
+    @SerializedName("processed")
+    private Map processed;
 
     /**
      * Gets the transaction id of the successful transaction.
@@ -18,7 +29,7 @@ public class SendTransactionResponse extends PushTransactionResponse {
      * @return The successful transaction id.
      */
     public String getTransactionId() {
-        return super.getTransactionId();
+        return transactionId;
     }
 
     /**
@@ -27,7 +38,7 @@ public class SendTransactionResponse extends PushTransactionResponse {
      * @return The successful processed details of the transaction.
      */
     public Map getProcessed() {
-        return super.getProcessed();
+        return processed;
     }
 
     /**
@@ -40,7 +51,13 @@ public class SendTransactionResponse extends PushTransactionResponse {
      * @return ArrayList of Objects containing the return values from the response.
      */
     public ArrayList<Object> getActionValues() {
-        return super.getActionValues();
+        ArrayList<Object> returnValues = new ArrayList<Object>();
+        if (processed == null) { return returnValues; }
+        if (!processed.containsKey("action_traces")) { return returnValues; }
+        for (Map trace : (List<Map>) processed.get("action_traces")) {
+            returnValues.add(trace.getOrDefault("return_value_data", null));
+        }
+        return returnValues;
     }
 
     /**
@@ -52,6 +69,9 @@ public class SendTransactionResponse extends PushTransactionResponse {
      * @throws IndexOutOfBoundsException if an incorrect index is requested.
      */
     public <T> T getActionValueAtIndex(int index, Class<T> clazz) throws IndexOutOfBoundsException, ClassCastException {
-        return super.getActionValueAtIndex(index, clazz);
+        ArrayList<Object> actionValues = getActionValues();
+        if (actionValues == null) { return null; }
+        Object actionValuesObj = actionValues.get(index);
+        return clazz.cast(actionValuesObj);
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/session/TransactionProcessor.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/session/TransactionProcessor.java
@@ -9,10 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import one.block.eosiojava.error.ErrorConstants;
 import one.block.eosiojava.error.abiProvider.GetAbiError;
-import one.block.eosiojava.error.rpcProvider.GetBlockRpcError;
-import one.block.eosiojava.error.rpcProvider.GetInfoRpcError;
-import one.block.eosiojava.error.rpcProvider.GetRequiredKeysRpcError;
-import one.block.eosiojava.error.rpcProvider.SendTransactionRpcError;
+import one.block.eosiojava.error.rpcProvider.*;
 import one.block.eosiojava.error.serializationProvider.DeserializeTransactionError;
 import one.block.eosiojava.error.serializationProvider.SerializeError;
 import one.block.eosiojava.error.serializationProvider.SerializePackedTransactionError;
@@ -50,13 +47,11 @@ import one.block.eosiojava.models.rpcProvider.Action;
 import one.block.eosiojava.models.rpcProvider.Transaction;
 import one.block.eosiojava.models.rpcProvider.ContextFreeData;
 import one.block.eosiojava.models.rpcProvider.TransactionConfig;
+import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetRequiredKeysRequest;
 import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
-import one.block.eosiojava.models.rpcProvider.response.GetBlockResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetInfoResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetRequiredKeysResponse;
-import one.block.eosiojava.models.rpcProvider.response.SendTransactionResponse;
+import one.block.eosiojava.models.rpcProvider.response.*;
 import one.block.eosiojava.models.signatureProvider.EosioTransactionSignatureRequest;
 import one.block.eosiojava.models.signatureProvider.EosioTransactionSignatureResponse;
 import one.block.eosiojava.utilities.DateFormatter;
@@ -408,18 +403,18 @@ public class TransactionProcessor {
             headBlockNum = BigInteger.valueOf(blockBehindConfig);
         }
 
-        GetBlockResponse getBlockResponse;
+        GetBlockInfoResponse getBlockInfoResponse;
         try {
-            getBlockResponse = this.rpcProvider
-                    .getBlock(new GetBlockRequest(headBlockNum.toString()));
-        } catch (GetBlockRpcError getBlockRpcError) {
+            getBlockInfoResponse = this.rpcProvider
+                    .getBlockInfo(new GetBlockInfoRequest(headBlockNum));
+        } catch (GetBlockInfoRpcError getBlockInfoRpcError) {
             throw new TransactionPrepareRpcError(
-                    ErrorConstants.TRANSACTION_PROCESSOR_PREPARE_RPC_GET_BLOCK, getBlockRpcError);
+                    ErrorConstants.TRANSACTION_PROCESSOR_PREPARE_RPC_GET_BLOCK_INFO, getBlockInfoRpcError);
         }
 
         // Restrict the refBlockNum to 32 bit unsigned value
-        BigInteger refBlockNum = getBlockResponse.getBlockNum().and(BigInteger.valueOf(0xffff));
-        BigInteger refBlockPrefix = getBlockResponse.getRefBlockPrefix();
+        BigInteger refBlockNum = getBlockInfoResponse.getBlockNum().and(BigInteger.valueOf(0xffff));
+        BigInteger refBlockPrefix = getBlockInfoResponse.getRefBlockPrefix();
 
         preparingTransaction.setRefBlockNum(refBlockNum);
         preparingTransaction.setRefBlockPrefix(refBlockPrefix);

--- a/eosiojava/src/test/java/one/block/eosiojava/session/NegativeTransactionProcessorTest.java
+++ b/eosiojava/src/test/java/one/block/eosiojava/session/NegativeTransactionProcessorTest.java
@@ -14,10 +14,7 @@ import java.util.List;
 import one.block.eosiojava.error.EosioError;
 import one.block.eosiojava.error.ErrorConstants;
 import one.block.eosiojava.error.abiProvider.GetAbiError;
-import one.block.eosiojava.error.rpcProvider.GetBlockRpcError;
-import one.block.eosiojava.error.rpcProvider.GetInfoRpcError;
-import one.block.eosiojava.error.rpcProvider.GetRequiredKeysRpcError;
-import one.block.eosiojava.error.rpcProvider.SendTransactionRpcError;
+import one.block.eosiojava.error.rpcProvider.*;
 import one.block.eosiojava.error.serializationProvider.DeserializeTransactionError;
 import one.block.eosiojava.error.serializationProvider.SerializeError;
 import one.block.eosiojava.error.serializationProvider.SerializeTransactionError;
@@ -44,9 +41,11 @@ import one.block.eosiojava.models.rpcProvider.Action;
 import one.block.eosiojava.models.rpcProvider.Authorization;
 import one.block.eosiojava.models.rpcProvider.Transaction;
 import one.block.eosiojava.models.rpcProvider.TransactionConfig;
+import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetRequiredKeysRequest;
 import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
+import one.block.eosiojava.models.rpcProvider.response.GetBlockInfoResponse;
 import one.block.eosiojava.models.rpcProvider.response.GetBlockResponse;
 import one.block.eosiojava.models.rpcProvider.response.GetInfoResponse;
 import one.block.eosiojava.models.rpcProvider.response.GetRequiredKeysResponse;
@@ -112,17 +111,17 @@ public class NegativeTransactionProcessorTest {
     @Test
     public void prepare_thenFailWithGetBlockError() throws TransactionPrepareError {
         exceptionRule.expect(TransactionPrepareRpcError.class);
-        exceptionRule.expectMessage(ErrorConstants.TRANSACTION_PROCESSOR_PREPARE_RPC_GET_BLOCK);
-        exceptionRule.expectCause(IsInstanceOf.<EosioError>instanceOf(GetBlockRpcError.class));
+        exceptionRule.expectMessage(ErrorConstants.TRANSACTION_PROCESSOR_PREPARE_RPC_GET_BLOCK_INFO);
+        exceptionRule.expectCause(IsInstanceOf.<EosioError>instanceOf(GetBlockInfoRpcError.class));
 
         // Mock RpcProvider
         this.mockGetInfoPositively();
 
         try {
-            when(this.mockedRpcProvider.getBlock(any(GetBlockRequest.class))).thenThrow(new GetBlockRpcError());
-        } catch (GetBlockRpcError getBlockRpcError) {
-            getBlockRpcError.printStackTrace();
-            fail("Exception should not be thrown here for mocking getBlock");
+            when(this.mockedRpcProvider.getBlockInfo(any(GetBlockInfoRequest.class))).thenThrow(new GetBlockInfoRpcError());
+        } catch (GetBlockInfoRpcError getBlockInfoRpcError) {
+            getBlockInfoRpcError.printStackTrace();
+            fail("Exception should not be thrown here for mocking getBlockInfo");
         }
 
         TransactionProcessor processor = session.getTransactionProcessor();
@@ -531,11 +530,11 @@ public class NegativeTransactionProcessorTest {
 
     private void mockGetBlockPositively() {
         try {
-            when(this.mockedRpcProvider.getBlock(any(GetBlockRequest.class)))
-                    .thenReturn(Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockResponse, GetBlockResponse.class));
-        } catch (GetBlockRpcError getBlockRpcError) {
-            getBlockRpcError.printStackTrace();
-            fail("Exception should not be thrown here for mocking getBlock");
+            when(this.mockedRpcProvider.getBlockInfo(any(GetBlockInfoRequest.class)))
+                    .thenReturn(Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockInfoResponse, GetBlockInfoResponse.class));
+        } catch (GetBlockInfoRpcError getBlockInfoRpcError) {
+            getBlockInfoRpcError.printStackTrace();
+            fail("Exception should not be thrown here for mocking getBlockInfo");
         }
     }
 
@@ -594,7 +593,7 @@ public class NegativeTransactionProcessorTest {
             + "    \"server_version_string\": \"v1.3.0\"\n"
             + "}";
 
-    private static final String mockedGetBlockResponse = "{\n"
+    private static final String mockedGetBlockInfoResponse = "{\n"
             + "    \"timestamp\": \"2019-04-01T22:08:38.500\",\n"
             + "    \"producer\": \"bp\",\n"
             + "    \"confirmed\": 0,\n"
@@ -602,11 +601,7 @@ public class NegativeTransactionProcessorTest {
             + "    \"transaction_mroot\": \"0000000000000000000000000000000000000000000000000000000000000000\",\n"
             + "    \"action_mroot\": \"1\",\n"
             + "    \"schedule_version\": 3,\n"
-            + "    \"new_producers\": null,\n"
-            + "    \"header_extensions\": [],\n"
             + "    \"producer_signature\": \"SIG\",\n"
-            + "    \"transactions\": [],\n"
-            + "    \"block_extensions\": [],\n"
             + "    \"id\": \"1\",\n"
             + "    \"block_num\": 31984399,\n"
             + "    \"ref_block_prefix\": " + refBlockPrefix + "\n"

--- a/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
+++ b/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
@@ -14,10 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import one.block.eosiojava.error.abiProvider.GetAbiError;
-import one.block.eosiojava.error.rpcProvider.GetBlockRpcError;
-import one.block.eosiojava.error.rpcProvider.GetInfoRpcError;
-import one.block.eosiojava.error.rpcProvider.GetRequiredKeysRpcError;
-import one.block.eosiojava.error.rpcProvider.SendTransactionRpcError;
+import one.block.eosiojava.error.rpcProvider.*;
 import one.block.eosiojava.error.serializationProvider.DeserializeTransactionError;
 import one.block.eosiojava.error.serializationProvider.SerializeError;
 import one.block.eosiojava.error.serializationProvider.SerializeTransactionError;
@@ -41,13 +38,11 @@ import one.block.eosiojava.models.rpcProvider.Authorization;
 import one.block.eosiojava.models.rpcProvider.ContextFreeData;
 import one.block.eosiojava.models.rpcProvider.Transaction;
 import one.block.eosiojava.models.rpcProvider.TransactionConfig;
+import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetRequiredKeysRequest;
 import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
-import one.block.eosiojava.models.rpcProvider.response.GetBlockResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetInfoResponse;
-import one.block.eosiojava.models.rpcProvider.response.GetRequiredKeysResponse;
-import one.block.eosiojava.models.rpcProvider.response.SendTransactionResponse;
+import one.block.eosiojava.models.rpcProvider.response.*;
 import one.block.eosiojava.models.signatureProvider.EosioTransactionSignatureRequest;
 import one.block.eosiojava.models.signatureProvider.EosioTransactionSignatureResponse;
 import one.block.eosiojava.utilities.DateFormatter;
@@ -83,7 +78,7 @@ public class TransactionProcessorTest {
 
         this.mockRPC(
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetInfoResponse, GetInfoResponse.class),
-                Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockResponse, GetBlockResponse.class),
+                Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockInfoResponse, GetBlockInfoResponse.class),
                 null, null);
 
         // Apply
@@ -390,7 +385,7 @@ public class TransactionProcessorTest {
     public void isAllowTransactionToBeModified() {
         this.mockRPC(
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetInfoResponse, GetInfoResponse.class),
-                Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockResponse, GetBlockResponse.class),
+                Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockInfoResponse, GetBlockInfoResponse.class),
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetRequiredKeysResponse, GetRequiredKeysResponse.class),
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(MOCKED_SENDTRANSACTION_RESPONE_JSON, SendTransactionResponse.class));
 
@@ -587,7 +582,7 @@ public class TransactionProcessorTest {
     private void mockDefaultSuccessData() {
         this.mockRPC(
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetInfoResponse, GetInfoResponse.class),
-                Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockResponse, GetBlockResponse.class),
+                Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetBlockInfoResponse, GetBlockInfoResponse.class),
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(mockedGetRequiredKeysResponse, GetRequiredKeysResponse.class),
                 Utils.getGson(DateFormatter.BACKEND_DATE_PATTERN).fromJson(MOCKED_SENDTRANSACTION_RESPONE_JSON, SendTransactionResponse.class));
 
@@ -662,7 +657,7 @@ public class TransactionProcessorTest {
 
     private void mockRPC(
             @Nullable GetInfoResponse getInfoResponse,
-            @Nullable GetBlockResponse getBlockResponse,
+            @Nullable GetBlockInfoResponse getBlockInfoResponse,
             @Nullable GetRequiredKeysResponse getRequiredKeysResponse,
             @Nullable SendTransactionResponse sendTransactionResponse) {
 
@@ -675,12 +670,12 @@ public class TransactionProcessorTest {
             }
         }
 
-        if (getBlockResponse != null) {
+        if (getBlockInfoResponse != null) {
             try {
-                when(mockedRpcProvider.getBlock(any(GetBlockRequest.class))).thenReturn(getBlockResponse);
-            } catch (GetBlockRpcError getBlockRpcError) {
-                getBlockRpcError.printStackTrace();
-                fail("Exception should not be thrown here for mocking getBlock");
+                when(mockedRpcProvider.getBlockInfo(any(GetBlockInfoRequest.class))).thenReturn(getBlockInfoResponse);
+            } catch (GetBlockInfoRpcError getBlockInfoRpcError) {
+                getBlockInfoRpcError.printStackTrace();
+                fail("Exception should not be thrown here for mocking getBlockInfo");
             }
         }
 
@@ -810,7 +805,7 @@ public class TransactionProcessorTest {
             + "    \"server_version_string\": \"v1.3.0\"\n"
             + "}";
 
-    private static final String mockedGetBlockResponse = "{\n"
+    private static final String mockedGetBlockInfoResponse = "{\n"
             + "    \"timestamp\": \"2019-04-01T22:08:38.500\",\n"
             + "    \"producer\": \"bp\",\n"
             + "    \"confirmed\": 0,\n"
@@ -818,11 +813,7 @@ public class TransactionProcessorTest {
             + "    \"transaction_mroot\": \"0000000000000000000000000000000000000000000000000000000000000000\",\n"
             + "    \"action_mroot\": \"1\",\n"
             + "    \"schedule_version\": 3,\n"
-            + "    \"new_producers\": null,\n"
-            + "    \"header_extensions\": [],\n"
             + "    \"producer_signature\": \"SIG\",\n"
-            + "    \"transactions\": [],\n"
-            + "    \"block_extensions\": [],\n"
             + "    \"id\": \"1\",\n"
             + "    \"block_num\": 31984399,\n"
             + "    \"ref_block_prefix\": " + refBlockPrefix + "\n"


### PR DESCRIPTION
Update IRPCProvider to replace GetBlock with GetBlockInfo since it is the recommended way to calculate TAPOS now.  GetBlock is still available.

Remove PushTransaction from IRPCProvider in favor of SendTransaction as it is the recommended endpoint now.  PushTransaction is still available.

Update transaction processing to use GetBlockInfo and remove any interface based references to GetBlock or PushTransaction.