### PR TITLE
Add use of last irreversible block to transaction processor config as default for TAPOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ One of the most complicated and time consuming tasks about encryption can be fig
 
 Transactions are instantiated via a `TransactionSession()` which must be configured with a number of providers and a `TransactionProcessor()`, which manipulates and performs actions on a Transaction, prior to use. The code below shows a very barebones flow. Error handling has been omitted for clarity but should be handled in normal usage. (See [Provider Interface Architecture](#provider-interface-architecture) below for more information about providers.)
 
+Some parameters for transaction processing can be altered by the use of the `TransactionConfig`.  These are `useLastIrreversible`, `blocksBehind` and `expiresSeconds`.  `TransactionConfig` defaults to `useLastIrreversible` equal to true, `blocksBehind` to 3 and `expiresSeconds` to 300.  When `useLastIrreversible` is true, `blocksBehind` is ignored and `TransactionProcessor` uses the last irreversible block and `expiresSeconds` to calculate TAPOS.  Otherwise, `TransactionProcessor` uses the current head block minus the number specified in `blocksBehind` and `expiresSeconds` for TAPOS.  `TransactionConfig` defaults to `useLastIrreversible` to lessen the chances of transactions micro-forking under certain conditions.
+
 ```java
 IRPCProvider rpcProvider = new EosioJavaRpcProviderImpl("https://baseurl.com/v1/");
 ISerializationProvider serializationProvider = new AbiEosSerializationProviderImpl();
@@ -104,6 +106,18 @@ TransactionSession session = new TransactionSession(
 );
 
 TransactionProcessor processor = session.getTransactionProcessor();
+
+// Now the TransactionConfig can be altered, if desired
+TransactionConfig transactionConfig = processor.getTransactionConfig();
+
+// Use blocksBehind (default 3) the current head block to calculate TAPOS
+transactionConfig.setUseLastIrreversible(false);
+// Set the expiration time of transactions 600 seconds later than the timestamp
+// of the block used to calculate TAPOS
+transactionConfig.setExpiresSeconds(600);
+
+// Update the TransactionProcessor with the config changes
+processor.setTransactionConfig(transactionConfig);
 
 String jsonData = "{\n" +
         "\"from\": \"person1\",\n" +

--- a/eosiojava/build.gradle
+++ b/eosiojava/build.gradle
@@ -47,7 +47,7 @@ test {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosiojava'
-def libraryVersion = '0.1.5-eosio2.1'
+def libraryVersion = '0.1.6-eosio2.1'
 
 task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'

--- a/eosiojava/src/main/java/one/block/eosiojava/error/ErrorConstants.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/error/ErrorConstants.java
@@ -179,7 +179,7 @@ public class ErrorConstants {
     /**
      * Error message get thrown if parsing head block time from {@link GetInfoResponse#getHeadBlockTime()} get error
      */
-    public static final String TRANSACTION_PROCESSOR_HEAD_BLOCK_TIME_PARSE_ERROR = "Failed to parse head block time";
+    public static final String TRANSACTION_PROCESSOR_TAPOS_BLOCK_TIME_PARSE_ERROR = "Failed to parse TAPOS block time";
 
     /**
      * Error message get thrown if making clone version of transaction is failed.

--- a/eosiojava/src/main/java/one/block/eosiojava/error/ErrorConstants.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/error/ErrorConstants.java
@@ -267,11 +267,6 @@ public class ErrorConstants {
     public static final String TRANSACTION_PROCESSOR_GET_SIGN_DESERIALIZE_TRANS_ERROR = "Error happened on calling deserializeTransaction to refresh transaction object with new values";
 
     /**
-     * Error message get thrown if {@link IRPCProvider#pushTransaction(PushTransactionRequest)} returns error.
-     */
-    public static final String TRANSACTION_PROCESSOR_RPC_PUSH_TRANSACTION = "Error happened on calling pushTransaction RPC call";
-
-    /**
      * Error message get thrown if {@link IRPCProvider#sendTransaction(SendTransactionRequest)} returns error.
      */
     public static final String TRANSACTION_PROCESSOR_RPC_SEND_TRANSACTION = "Error happened on calling sendTransaction RPC call";

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/TransactionConfig.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/TransactionConfig.java
@@ -41,16 +41,17 @@ public class TransactionConfig {
      * The amount blocks behind from head block.
      * <br>
      * It is an argument to calculate head block number to call {@link
-     * one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)}
+     * one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
      */
     private int blocksBehind = DEFAULT_BLOCKS_BEHIND;
 
     /**
      * Use the last irreversible block when calculating TAPOS rather than blocks behind.
      * <br>
-     * Mutually exclusive with {@link TransactionConfig#setBlocksBehind(int)}.  If set, TAPOS will be calculated
-     * by fetching the last irreversible block with {@link IRPCProvider#getInfo()} and expire the transaction
-     * {@link TransactionConfig#setExpiresSeconds(int)} after that block's time.
+     * Mutually exclusive with {@link TransactionConfig#setBlocksBehind(int)}.  If set,
+     * {@link TransactionConfig#getBlocksBehind()} will be ignored and TAPOS will be calculated by fetching the last
+     * irreversible block with {@link IRPCProvider#getInfo()} and the expiration for the transaction
+     * will be set {@link TransactionConfig#setExpiresSeconds(int)} after that block's time.
      */
     private boolean useLastIrreversible = DEFAULT_USE_LAST_IRREVERSIBLE;
 

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/TransactionConfig.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/TransactionConfig.java
@@ -1,5 +1,7 @@
 package one.block.eosiojava.models.rpcProvider;
 
+import one.block.eosiojava.interfaces.IRPCProvider;
+import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 import one.block.eosiojava.models.rpcProvider.response.GetInfoResponse;
 
@@ -22,6 +24,12 @@ public class TransactionConfig {
     private static final int DEFAULT_EXPIRES_SECONDS = 5 * 60;
 
     /**
+     * Default useLastIrreversible to use last irreversible block rather than blocksBehind when
+     * calculating TAPOS
+     */
+    private static final boolean DEFAULT_USE_LAST_IRREVERSIBLE = true;
+
+    /**
      * The Expires seconds.
      * <br>
      * Append this value to {@link GetInfoResponse#getHeadBlockTime()} in second then assign it to
@@ -36,6 +44,15 @@ public class TransactionConfig {
      * one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)}
      */
     private int blocksBehind = DEFAULT_BLOCKS_BEHIND;
+
+    /**
+     * Use the last irreversible block when calculating TAPOS rather than blocks behind.
+     * <br>
+     * Mutually exclusive with {@link TransactionConfig#setBlocksBehind(int)}.  If set, TAPOS will be calculated
+     * by fetching the last irreversible block with {@link IRPCProvider#getInfo()} and expire the transaction
+     * {@link TransactionConfig#setExpiresSeconds(int)} after that block's time.
+     */
+    private boolean useLastIrreversible = DEFAULT_USE_LAST_IRREVERSIBLE;
 
     /**
      * Gets the expiration time for the transaction.
@@ -64,8 +81,7 @@ public class TransactionConfig {
     /**
      * Gets blocks behind.
      * <br>
-     * It is an argument to calculate head block number to call {@link
-     * one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)}
+     * It is an argument to calculate head block number to call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
      * @return the blocks behind
      */
     public int getBlocksBehind() {
@@ -76,10 +92,28 @@ public class TransactionConfig {
      * Sets blocks behind.
      * <br>
      * It is an argument to calculate head block number to call {@link
-     * one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)}
+     * one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
      * @param blocksBehind the blocks behind
      */
     public void setBlocksBehind(int blocksBehind) {
         this.blocksBehind = blocksBehind;
+    }
+
+    /**
+     * Gets useLastIrreversible.
+     * <br>
+     * It is an argument to calculate TAPOS from the last irreversible block rather than blocks behind the head block
+     * @return useLastIrreversible whether to use the last irreversible block for calculating TAPOS
+     */
+    public boolean getUseLastIrreversible() { return useLastIrreversible; }
+
+    /**
+     * Sets useLastIrreversible.
+     * <br>
+     * It is an argument to calculate TAPOS from the last irreversible block rather than blocks behind the head block
+     * @param useLastIrreversible whether to use the last irreversible block
+     */
+    public void setUseLastIrreversible(boolean useLastIrreversible) {
+        this.useLastIrreversible = useLastIrreversible;
     }
 }

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/GetBlockInfoRequest.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/GetBlockInfoRequest.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import java.math.BigInteger;
 
 /**
- * The request class for getBlockInfo() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockInfoRequest)}
+ * The request class for getBlockInfo() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
  */
 public class GetBlockInfoRequest {
 

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/GetBlockRequest.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/request/GetBlockRequest.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The request class for getBlock() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)}
+ * The request class for getBlock() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
  */
 public class GetBlockRequest {
 

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/GetBlockResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/GetBlockResponse.java
@@ -4,10 +4,12 @@ import com.google.gson.annotations.SerializedName;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+
+import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 
 /**
- * The response of getBlock() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)}
+ * The response of getBlock() RPC call {@link one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)}
  */
 public class GetBlockResponse {
 

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/GetInfoResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/GetInfoResponse.java
@@ -5,6 +5,7 @@ import java.math.BigInteger;
 import java.util.List;
 import one.block.eosiojava.interfaces.IRPCProvider;
 import one.block.eosiojava.models.rpcProvider.Transaction;
+import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 
 /**
@@ -88,7 +89,7 @@ public class GetInfoResponse {
 
     /**
      * Gets the head block number. It is an argument used to specify the reference block to call {@link
-     * one.block.eosiojava.interfaces.IRPCProvider#getBlock(GetBlockRequest)} at {@link
+     * one.block.eosiojava.interfaces.IRPCProvider#getBlockInfo(GetBlockInfoRequest)} at {@link
      * one.block.eosiojava.session.TransactionProcessor#prepare(List)}
      * @return the head block number.
      */

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/PushTransactionResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/PushTransactionResponse.java
@@ -10,7 +10,6 @@ import one.block.eosiojava.models.rpcProvider.request.PushTransactionRequest;
 
 /**
  * The response of the pushTransaction() RPC call
- * {@link one.block.eosiojava.interfaces.IRPCProvider#pushTransaction(PushTransactionRequest)}
  */
 public class PushTransactionResponse extends SendTransactionResponse {
 

--- a/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/SendTransactionResponse.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/models/rpcProvider/response/SendTransactionResponse.java
@@ -64,6 +64,7 @@ public class SendTransactionResponse {
      * Get the action value at the specified index, if it exists and return it as the passed in type.
      * @param index The index of the action value returns to retrieve.
      * @param clazz The class type to cast the action value to, if found.
+     * @param <T> Typed return.
      * @return The action value as the desired type or null if not found or is the wrong type.
      * @throws ClassCastException if the value cannot be cast to the requested type.
      * @throws IndexOutOfBoundsException if an incorrect index is requested.

--- a/eosiojava/src/main/java/one/block/eosiojava/session/TransactionProcessor.java
+++ b/eosiojava/src/main/java/one/block/eosiojava/session/TransactionProcessor.java
@@ -48,7 +48,6 @@ import one.block.eosiojava.models.rpcProvider.Transaction;
 import one.block.eosiojava.models.rpcProvider.ContextFreeData;
 import one.block.eosiojava.models.rpcProvider.TransactionConfig;
 import one.block.eosiojava.models.rpcProvider.request.GetBlockInfoRequest;
-import one.block.eosiojava.models.rpcProvider.request.GetBlockRequest;
 import one.block.eosiojava.models.rpcProvider.request.GetRequiredKeysRequest;
 import one.block.eosiojava.models.rpcProvider.request.SendTransactionRequest;
 import one.block.eosiojava.models.rpcProvider.response.*;
@@ -411,7 +410,7 @@ public class TransactionProcessor {
                 taposBlockTime = DateFormatter.convertBackendTimeToMilli(strHeadBlockTime);
             } catch (ParseException e) {
                 throw new TransactionPrepareError(
-                        ErrorConstants.TRANSACTION_PROCESSOR_HEAD_BLOCK_TIME_PARSE_ERROR, e);
+                        ErrorConstants.TRANSACTION_PROCESSOR_TAPOS_BLOCK_TIME_PARSE_ERROR, e);
             }
 
             int expiresSeconds = this.transactionConfig.getExpiresSeconds();

--- a/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
+++ b/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
@@ -74,6 +74,10 @@ public class TransactionProcessorTest {
     public void prepare() {
         // Test start
         TransactionProcessor processor = session.getTransactionProcessor();
+        TransactionConfig transactionConfig = processor.getTransactionConfig();
+        transactionConfig.setUseLastIrreversible(false);
+        transactionConfig.setExpiresSeconds(600);
+        processor.setTransactionConfig(transactionConfig);
         assertNotNull(processor);
 
         this.mockRPC(

--- a/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
+++ b/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
@@ -782,8 +782,8 @@ public class TransactionProcessorTest {
 
 
     // Expectation
-    // headBlockTime + default 5 minutes
-    private static final String expectedExpiration = "2019-04-01T22:13:40.000";
+    // getBlockInfo Timestamp + default 5 minutes
+    private static final String expectedExpiration = "2019-04-01T22:13:38.500";
     private static TransactionConfig transactionConfig = new TransactionConfig();
     private static final BigInteger expectedRefBlockNum = headBlockNum.subtract(BigInteger.valueOf(transactionConfig.getBlocksBehind()))
             .and(BigInteger.valueOf(0xffff));

--- a/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
+++ b/eosiojava/src/test/java/one/block/eosiojava/session/TransactionProcessorTest.java
@@ -74,10 +74,6 @@ public class TransactionProcessorTest {
     public void prepare() {
         // Test start
         TransactionProcessor processor = session.getTransactionProcessor();
-        TransactionConfig transactionConfig = processor.getTransactionConfig();
-        transactionConfig.setUseLastIrreversible(false);
-        transactionConfig.setExpiresSeconds(600);
-        processor.setTransactionConfig(transactionConfig);
         assertNotNull(processor);
 
         this.mockRPC(


### PR DESCRIPTION
Added useLastIrreversible to TransactionConfig and default to true.
When useLastIrreversible is true, then blocksBehind will be ignored and the last irreversible block and expiresSeconds will be used to calculate TAPOS.
When useLastIrreversible is false, then transaction processing will take the current head block minus blocksBehind and expiresSeconds and use them to calculate TAPOS.
Fix issue with blocksBehind transaction expiration time. It was previously being calculated from the current head block time rather than the time stamp of the block found using blocksBehind.
Update javadoc and README to include information on useLastIrreversible.